### PR TITLE
Very dirty hack to be able to embed lists of objects.

### DIFF
--- a/src/Servant/Hateoas/ContentType/HAL.hs
+++ b/src/Servant/Hateoas/ContentType/HAL.hs
@@ -55,7 +55,10 @@ renderHalLink l = object $
     <> maybe mempty (\t -> ["title" .= t]) (_title l)
 
 instance {-# OVERLAPPABLE #-} ToJSON a => ToJSON (HALResource a) where
-  toJSON (HALResource res ls es) = Object $ (singleton "_links" ls') <> (singleton "_embedded" es') <> (case toJSON res of Object kvm -> kvm ; _ -> mempty)
+  toJSON (HALResource res ls es) = case (toJSON res, ls, es) of
+    -- This is such a dirty hack - but still the easiest way to embed a collection of resources.
+    (Array arr, [], []) -> Array arr
+    _ -> Object $ (singleton "_links" ls') <> (singleton "_embedded" es') <> (case toJSON res of Object kvm -> kvm ; _ -> mempty)
     where
       ls' = object [fromString rel .= renderHalLink l | (rel, l) <- ls]
       es' = object [fromString name .= toJSON e | (name, (Some1 e)) <- es]


### PR DESCRIPTION
This is really evil - but I was searching for way to embed lists of resources into the HAL representation. So this small change allows to generate resource representations like the following (please note the direct JSON Array below the embedded "close-friends"):

```json
{
  "_embedded": {
    "close-friends": [
      {
        "_embedded": {},
        "_links": {
          "address": {
            "href": "/api/address/2",
            "type": "application/hal+json"
          },
          "close-friends": {
            "href": "/api/user/2/close-friends",
            "type": "application/hal+json"
          },
          "friends": {
            "href": "/api/user/2/friends",
            "type": "application/hal+json"
          },
          "self": {
            "href": "/api/user/2",
            "title": "The user with the given id",
            "type": "application/hal+json"
          }
        },
        "income": 2000,
        "name": "Bob"
      }
    ]
  },
  "_links": {
    "address": {
      "href": "/api/address/1",
      "type": "application/hal+json"
    },
    "close-friends": {
      "href": "/api/user/1/close-friends",
      "type": "application/hal+json"
    },
    "friends": {
      "href": "/api/user/1/friends",
      "type": "application/hal+json"
    },
    "self": {
      "href": "/api/user/1",
      "title": "The user with the given id",
      "type": "application/hal+json"
    }
  },
  "income": 1000,
  "name": "Alice"
}
```

If there is a better way, please let me know :+1: With this change I think I have found solutions or workarounds for all the things that came to my mind during playing around. 

So I'm happy to polish the PRs as needed, but as far as I can see for it now I will not try to realize/evaluate more features.